### PR TITLE
Add mock to the testing requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ pytest-flakes==1.0.1
 pytest-pep8==1.0.6
 pep8==1.7.0
 coverage==4.2
+mock==2.0.0


### PR DESCRIPTION
It was missing, and without them, tests didn’t run locally.

In Travis it was working because [`mock` is pre-installed](https://docs.travis-ci.com/user/languages/python/#Pre-installed-packages).