### PR TITLE
Fix critical bug

### DIFF
--- a/flask_sendgrid.py
+++ b/flask_sendgrid.py
@@ -46,8 +46,15 @@ class SendGrid(SGMail):
         self.api_key = app.config['SENDGRID_API_KEY']
         self.default_from = app.config['SENDGRID_DEFAULT_FROM']
         self.client = SendGridAPIClient(apikey=self.api_key).client
+        
+    def clear_mail_data(self):
+        """Clear mail data before sending a new one. Otherwise, the personalizations and contents attribute
+        will de duplicated, and the SendGrid API will return a 400 Bad Request response."""
+        self._contents = None
+        self._personalizations = None
 
     def send_email(self, to_email, subject, from_email=None, html=None, text=None, *args, **kwargs):  # noqa
+        self.clear_mail_data()
         if not any([from_email, self.default_from]):
             raise ValueError("Missing from email and no default.")
         if not any([html, text]):

--- a/flask_sendgrid.py
+++ b/flask_sendgrid.py
@@ -46,7 +46,7 @@ class SendGrid(SGMail):
         self.api_key = app.config['SENDGRID_API_KEY']
         self.default_from = app.config['SENDGRID_DEFAULT_FROM']
         self.client = SendGridAPIClient(apikey=self.api_key).client
-        
+
     def clear_mail_data(self):
         """Clear mail data before sending a new one. Otherwise, the personalizations and contents attribute
         will de duplicated, and the SendGrid API will return a 400 Bad Request response."""


### PR DESCRIPTION
Currently, the self._contents and self._personalizations attribute are continuously appended to, causing duplicates in the resulting JSON payload, and hence a Bad Request 400 error from the SendGrid API. I've changed the class implementation to clear those two attributes before each send_mail call to avoid this problem.

This is a critical bug that crashes in any flask application after the first email is sent. 